### PR TITLE
crt-lottes and pixellate now use hardware linearization

### DIFF
--- a/crt/crt-lottes.glsl
+++ b/crt/crt-lottes.glsl
@@ -1,5 +1,8 @@
 #version 120
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 // PUBLIC DOMAIN CRT STYLED SCAN-LINE SHADER
 //
 //   by Timothy Lottes
@@ -127,7 +130,6 @@ uniform COMPAT_PRECISION float shape;
 #define warpY 0.041
 #define maskDark 0.5
 #define maskLight 1.5
-#define scaleInLinearGamma 1.0
 #define shadowMask 3.0
 #define brightBoost 1.0
 #define hardBloomPix -1.5
@@ -138,71 +140,14 @@ uniform COMPAT_PRECISION float shape;
 
 //Uncomment to reduce instructions with simpler linearization
 //(fixes HD3000 Sandy Bridge IGP)
-//#define SIMPLE_LINEAR_GAMMA
 #define DO_BLOOM
 
-// ------------- //
-
-// sRGB to Linear.
-// Assuming using sRGB typed textures this should not be needed.
-#ifdef SIMPLE_LINEAR_GAMMA
-float ToLinear1(float c)
-{
-	return c;
-}
-vec3 ToLinear(vec3 c)
-{
-	return c;
-}
-vec3 ToSrgb(vec3 c)
-{
-	return pow(c, vec3(1.0 / 2.2));
-}
-#else
-float ToLinear1(float c)
-{
-	if (scaleInLinearGamma == 0.)
-		return c;
-
-	return(c<=0.04045) ? c/12.92 : pow((c + 0.055)/1.055, 2.4);
-}
-
-vec3 ToLinear(vec3 c)
-{
-	if (scaleInLinearGamma==0.)
-		return c;
-
-	return vec3(ToLinear1(c.r), ToLinear1(c.g), ToLinear1(c.b));
-}
-
-// Linear to sRGB.
-// Assuming using sRGB typed textures this should not be needed.
-float ToSrgb1(float c)
-{
-	if (scaleInLinearGamma == 0.)
-		return c;
-
-	return(c<0.0031308 ? c*12.92 : 1.055*pow(c, 0.41666) - 0.055);
-}
-
-vec3 ToSrgb(vec3 c)
-{
-	if (scaleInLinearGamma == 0.)
-		return c;
-
-	return vec3(ToSrgb1(c.r), ToSrgb1(c.g), ToSrgb1(c.b));
-}
-#endif
 
 // Nearest emulated sample given floating point position and texel offset.
 // Also zero's off screen.
 vec3 Fetch(vec2 pos,vec2 off){
   pos=(floor(pos*SourceSize.xy+off)+vec2(0.5,0.5))/SourceSize.xy;
-#ifdef SIMPLE_LINEAR_GAMMA
-  return ToLinear(brightBoost * pow(COMPAT_TEXTURE(Source,pos.xy).rgb, vec3(2.2)));
-#else
-  return ToLinear(brightBoost * COMPAT_TEXTURE(Source,pos.xy).rgb);
-#endif
+  return brightBoost * COMPAT_TEXTURE(Source,pos.xy).rgb;
 }
 
 // Distance in emulated pixels to nearest texel.
@@ -419,6 +364,6 @@ void main()
 	else
 		outColor.rgb = vec3(0.0);
 #endif
-	FragColor = vec4(ToSrgb(outColor.rgb), 1.0);
+	FragColor = vec4(outColor.rgb, 1.0);
 }
 #endif

--- a/interpolation/pixellate.glsl
+++ b/interpolation/pixellate.glsl
@@ -1,5 +1,8 @@
 #version 120
 
+#pragma use_srgb_texture
+#pragma use_srgb_framebuffer
+
 //    Pixellate Shader
 //    Copyright (c) 2011, 2012 Fes
 //    Permission to use, copy, modify, and/or distribute this software for any
@@ -15,8 +18,6 @@
 //    (Fes gave their permission to have this shader distributed under this
 //    licence in this forum post:
 //        http://board.byuu.org/viewtopic.php?p=57295#p57295
-
-#define INTERPOLATE_IN_LINEAR_GAMMA 1.0
 
 uniform vec2 rubyTextureSize;
 uniform vec2 rubyInputSize;
@@ -106,13 +107,6 @@ void main()
 	vec3 bottomLeftColor  = COMPAT_TEXTURE(Source, (floor(vec2(left, bottom)  / texelSize) + 0.5) * texelSize).rgb;
 	vec3 topRightColor    = COMPAT_TEXTURE(Source, (floor(vec2(right, top)    / texelSize) + 0.5) * texelSize).rgb;
 
-	if (INTERPOLATE_IN_LINEAR_GAMMA > 0.5){
-	topLeftColor     = pow(topLeftColor, vec3(2.2));
-	bottomRightColor = pow(bottomRightColor, vec3(2.2));
-	bottomLeftColor  = pow(bottomLeftColor, vec3(2.2));
-	topRightColor    = pow(topRightColor, vec3(2.2));
-	}
-
 	vec2 border = clamp(floor((vTexCoord / texelSize) + vec2(0.5)) * texelSize, vec2(left, bottom), vec2(right, top));
 
 	float totalArea = 4.0 * range.x * range.y;
@@ -123,6 +117,6 @@ void main()
 	averageColor += ((border.x - left)  * (border.y - bottom) / totalArea) * bottomLeftColor;
 	averageColor += ((right - border.x) * (top - border.y)    / totalArea) * topRightColor;
 
-	FragColor = (INTERPOLATE_IN_LINEAR_GAMMA > 0.5) ? vec4(pow(averageColor, vec3(1.0 / 2.2)), 1.0) : vec4(averageColor, 1.0);
+	FragColor = vec4(averageColor, 1.0);
 }
 #endif


### PR DESCRIPTION
Hey @tyrells, we have added support for sRGB textures and framebuffers for GLSL shaders in DOSBox Staging (see [here](https://github.com/dosbox-staging/dosbox-staging/pull/1649)). Shaders can now request these features via pragmas:

```
#pragma use_srgb_texture
#pragma use_srgb_framebuffer
```

The nice thing about this is that it's completely backwards compatible -- the shader compiler will always ignore these unknown pragmas, it's a pre-processor step in DOSBox Staging that looks for them.

We are definitely planning to merge this feature back upstream into the DOSBox SVN branch.

This PR updates all shaders in your repo that benefit from proper gamma-correct interpolation. I've tried to add it to all shaders that don't do their own linearisation (like most CRT shaders), but sadly they seem to be tuned for incorrect "sRGB space" interpolation so they look quite different and basically broken when things are done in the mathematically correct way. Because of this, I've just left them alone.

If you're interested, here are our discussions with before/after screenshots about why we introduced this feature in the first place, but I'm sure you're aware of all the reasons:

https://github.com/dosbox-staging/dosbox-staging/pull/1627
https://github.com/dosbox-staging/dosbox-staging/pull/1634


